### PR TITLE
Fix prelink-riscv so that it works on big endian build hosts

### DIFF
--- a/tools/prelink-riscv.c
+++ b/tools/prelink-riscv.c
@@ -8,10 +8,6 @@
  * without fixup. Both RV32 and RV64 are supported.
  */
 
-#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
-#error "Only little-endian host is supported"
-#endif
-
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -25,6 +21,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <endian.h>
 
 #ifndef EM_RISCV
 #define EM_RISCV 243

--- a/tools/prelink-riscv.inc
+++ b/tools/prelink-riscv.inc
@@ -23,14 +23,15 @@
 #define Elf_Addr        CONCAT3(Elf, PRELINK_INC_BITS, _Addr)
 #define ELF_R_TYPE      CONCAT3(ELF, PRELINK_INC_BITS, _R_TYPE)
 #define ELF_R_SYM       CONCAT3(ELF, PRELINK_INC_BITS, _R_SYM)
+#define lenntoh         CONCAT3(le, PRELINK_INC_BITS, toh)
 
 static void* get_offset_nn (void* data, Elf_Phdr* phdrs, size_t phnum, Elf_Addr addr)
 {
 	Elf_Phdr *p;
 
 	for (p = phdrs; p < phdrs + phnum; ++p)
-		if (p->p_vaddr <= addr && p->p_vaddr + p->p_memsz > addr)
-			return data + p->p_offset + (addr - p->p_vaddr);
+		if (lenntoh(p->p_vaddr) <= addr && lenntoh(p->p_vaddr) + lenntoh(p->p_memsz) > addr)
+			return data + lenntoh(p->p_offset) + (addr - lenntoh(p->p_vaddr));
 
 	return NULL;
 }
@@ -42,15 +43,15 @@ static void prelink_nn(void *data)
 	Elf_Dyn *dyn;
 	Elf_Rela *r;
 
-	if (ehdr->e_machine != EM_RISCV)
+	if (le16toh(ehdr->e_machine) != EM_RISCV)
 		die("Machine type is not RISC-V");
 
-	Elf_Phdr *phdrs = data + ehdr->e_phoff;
+	Elf_Phdr *phdrs = data + lenntoh(ehdr->e_phoff);
 
 	Elf_Dyn *dyns = NULL;
-	for (p = phdrs; p < phdrs + ehdr->e_phnum; ++p) {
-		if (p->p_type == PT_DYNAMIC) {
-			dyns = data + p->p_offset;
+	for (p = phdrs; p < phdrs + le16toh(ehdr->e_phnum); ++p) {
+		if (le32toh(p->p_type) == PT_DYNAMIC) {
+			dyns = data + lenntoh(p->p_offset);
 			break;
 		}
 	}
@@ -62,14 +63,14 @@ static void prelink_nn(void *data)
 	size_t rela_count = 0;
 	Elf_Sym *dynsym = NULL;
 	for (dyn = dyns;; ++dyn) {
-		if (dyn->d_tag == DT_NULL)
+		if (lenntoh(dyn->d_tag) == DT_NULL)
 			break;
-		else if (dyn->d_tag == DT_RELA)
-			rela_dyn = get_offset_nn(data, phdrs, ehdr->e_phnum, + dyn->d_un.d_ptr);
-		else if (dyn->d_tag == DT_RELASZ)
-			rela_count = dyn->d_un.d_val / sizeof(Elf_Rela);
-		else if (dyn->d_tag == DT_SYMTAB)
-			dynsym = get_offset_nn(data, phdrs, ehdr->e_phnum, + dyn->d_un.d_ptr);
+		else if (lenntoh(dyn->d_tag) == DT_RELA)
+			rela_dyn = get_offset_nn(data, phdrs, le16toh(ehdr->e_phnum), + lenntoh(dyn->d_un.d_ptr));
+		else if (lenntoh(dyn->d_tag) == DT_RELASZ)
+		  rela_count = lenntoh(dyn->d_un.d_val) / sizeof(Elf_Rela);
+		else if (lenntoh(dyn->d_tag) == DT_SYMTAB)
+			dynsym = get_offset_nn(data, phdrs, le16toh(ehdr->e_phnum), + lenntoh(dyn->d_un.d_ptr));
 
 	}
 
@@ -80,17 +81,17 @@ static void prelink_nn(void *data)
 		die("No .dynsym found");
 
 	for (r = rela_dyn; r < rela_dyn + rela_count; ++r) {
-		void* buf = get_offset_nn(data, phdrs, ehdr->e_phnum, r->r_offset);
+		void* buf = get_offset_nn(data, phdrs, le16toh(ehdr->e_phnum), lenntoh(r->r_offset));
 
 		if (buf == NULL)
 			continue;
 
-		if (ELF_R_TYPE(r->r_info) == R_RISCV_RELATIVE)
+		if (ELF_R_TYPE(lenntoh(r->r_info)) == R_RISCV_RELATIVE)
 			*((uintnn_t*) buf) = r->r_addend;
-		else if (ELF_R_TYPE(r->r_info) == R_RISCV_32)
-			*((uint32_t*) buf) = dynsym[ELF_R_SYM(r->r_info)].st_value;
-		else if (ELF_R_TYPE(r->r_info) == R_RISCV_64)
-			*((uint64_t*) buf) = dynsym[ELF_R_SYM(r->r_info)].st_value;
+		else if (ELF_R_TYPE(lenntoh(r->r_info)) == R_RISCV_32)
+			*((uint32_t*) buf) = dynsym[ELF_R_SYM(lenntoh(r->r_info))].st_value;
+		else if (ELF_R_TYPE(lenntoh(r->r_info)) == R_RISCV_64)
+			*((uint64_t*) buf) = dynsym[ELF_R_SYM(lenntoh(r->r_info))].st_value;
 	}
 }
 


### PR DESCRIPTION
With this fix I can build the entire freedom-sdk on my Talos II.